### PR TITLE
Feature/36 process enceladus checkpoints

### DIFF
--- a/spot/crawler/elastic.py
+++ b/spot/crawler/elastic.py
@@ -94,7 +94,7 @@ class Elastic:
                                  ignore=[400, 409],
                                  request_timeout=REQUEST_TIMEOUT)
         if res.get('result') == 'created':
-            logger.debug(f'{uid} added to {self._raw_index}')
+            logger.debug(f'{uid} added to {index}')
         else:
             self._process_elasticsearch_error(res)
 

--- a/spot/enceladus/menas_aggregator.py
+++ b/spot/enceladus/menas_aggregator.py
@@ -24,14 +24,14 @@ logger = logging.getLogger(__name__)
 
 
 # Checkpoints may have different datetime formats
-def try_parsing_date(text):
+def parse_date(text):
     for fmt in ["%d-%m-%Y %H:%M:%S %z", "%d-%m-%Y %H:%M:%S"]:
         try:
             return datetime.strptime(text, fmt)
         except ValueError:
             pass
     logger.warning(f"No valid date format found for {text}")
-    return None
+    return
 
 
 def _match_values(left, right):
@@ -84,7 +84,7 @@ class MenasAggregator:
         additional_info = run['controlMeasure']['metadata']['additionalInfo']
         for key, value in additional_info.items():
             additional_info[key] = cast_string_to_value(value)
-        start_date_time = try_parsing_date(run.get('startDateTime'))
+        start_date_time = parse_date(run.get('startDateTime'))
         return run
 
     def get_runs(self, app_id, clfsion):
@@ -150,54 +150,55 @@ class MenasAggregator:
             if run is not None:
                 # pop  original checkpoints array from run
                 raw_checkpoints = run.get('controlMeasure', None).pop('checkpoints', None)
-                # add aggregations of checkpoints to run
-                run['controlMeasure']['checkpoints'] = MenasAggregator._aggregate_checkpoints(raw_checkpoints)
+                if raw_checkpoints is not None:
+                    # add aggregations of checkpoints to run
+                    run['controlMeasure']['checkpoints'] = MenasAggregator._aggregate_checkpoints(raw_checkpoints)
         return app
 
     @staticmethod
     def _aggregate_checkpoints(raw_checkpoints):
         new_checkpoints = {'elements_count': len(raw_checkpoints)}
         control_values_match = True
-        if raw_checkpoints is None:
-            logger.warning('Checkpoints not found in run object')
-        else:
-            agg_checkpoints = {}
-            reference_controls = {}
-            for checkpoint in raw_checkpoints:
-                name = checkpoint.get('name').replace(' ', '')
-                checkpoint['name'] = name
+        agg_checkpoints = {}
+        reference_controls = {}
+        for checkpoint in raw_checkpoints:
+            checkpoint['name'] = checkpoint['name'].replace(' ', '')
+            process_start_time = parse_date(checkpoint.pop('processStartTime'))
+            process_end_time = parse_date(checkpoint.pop('processEndTime'))
 
-                process_start_time = try_parsing_date(checkpoint.pop('processStartTime'))
-                process_end_time = try_parsing_date(checkpoint.pop('processEndTime'))
-                if (process_start_time is not None) and (process_end_time is not None):
-                    checkpoint['processStartTime'] = process_start_time
-                    checkpoint['processEndTime'] = process_end_time
-                    duration = (process_end_time - process_start_time).total_seconds() * 1000
-                    checkpoint['duration'] = duration
+            # if the times cannot be casted correctly, the fields are skipped, not to interfere with ES schema
+            if (process_start_time is not None) and (process_end_time is not None):
+                checkpoint['processStartTime'] = process_start_time
+                checkpoint['processEndTime'] = process_end_time
+                duration = (process_end_time - process_start_time).total_seconds() * 1000
+                checkpoint['duration'] = duration
 
-                controls = checkpoint.pop('controls', None)
+            controls = checkpoint.pop('controls', None)
 
-                if control_values_match: # we only check control values until first mismatch
-                    if not reference_controls: # the first checkpoint's controls are set as a reference
-                        for control in controls:
-                            reference_controls[control['controlName']] = control['controlValue']
-                    else: # reference controls already set in first checkpoint
-                        for control in controls:
-                            if not reference_controls[control['controlName']] == control['controlValue']:
-                                control_values_match = False
-                                control_values_error = {
-                                    'checkpoint': checkpoint,
-                                    'controlName':control['controlName'],
-                                    'controlValue': control['controlValue'],
-                                    'initialControlValue': reference_controls[control['controlName']]
-                                }
-                                new_checkpoints['control_values_error'] = control_values_error
-                                break
+            if control_values_match: # we only check control values until first mismatch
+                if not reference_controls: # the first checkpoint's controls are set as a reference
+                    for control in controls:
+                        reference_controls[control['controlName']] = control['controlValue']
+                else: # reference controls already set in first checkpoint
+                    for control in controls:
+                        # the control values are originally stored as strings
+                        # we assume '123' and '123.0' are distinct values
+                        # as they also should be of the same type and precision
+                        if not reference_controls[control['controlName']] == control['controlValue']:
+                            control_values_match = False
+                            control_values_error = {
+                                'checkpoint': checkpoint,
+                                'controlName':control['controlName'],
+                                'controlValue': control['controlValue'],
+                                'initialControlValue': reference_controls[control['controlName']]
+                            }
+                            new_checkpoints['control_values_error'] = control_values_error
+                            break
 
-                # save checkpoint
-                agg_checkpoints[name] = checkpoint
+            # save checkpoint
+            agg_checkpoints[checkpoint['name']] = checkpoint
 
-            new_checkpoints['agg_checkpoints'] = agg_checkpoints
-            new_checkpoints['control_values_match'] = control_values_match
+        new_checkpoints['agg_checkpoints'] = agg_checkpoints
+        new_checkpoints['control_values_match'] = control_values_match
         return new_checkpoints
 


### PR DESCRIPTION
The new feature aggregates Enceladus run checkpoints in the following way:
replaces original attribute 'checkpoints' in run object (which contained array of checkpoints) with a new one that contains:
element_count - number of checkpoints in original array
control_values_match - control values of each checkpoint are compared against the first checkpoint. It is assumed that all the controls are identified by unique names, and their values should be equal at each checkpoint. The controls are checked until the first mismatch is encountered. Controls are compared as strings (the original format), therefore values of 123 and 123.0 are considered different. 
control_values_error - if controls mismatch encountered, this attribute is added and contains: 
                "controlName" - name of the mismatching control
                "controlValue" - value of the mismatching control
                "initialControlValue" - value of this control in the first checkpoint
                "checkpoint" - Details of the checkpoint where the mismatch is first encountered
 

agg_checkpoints - all the checkpoints from the original array transformed into a map. In the output map each checkpoint has 
   - key equal to its 'name'
  - processStartTime and processEndTime are casted to datetime when matching one of possible patterns: ["%d-%m-%Y %H:%M:%S %z", "%d-%m-%Y %H:%M:%S"]
  - duration in milliseconds (When both  processStartTime and processEndTime are casted correctly)
  - array of control measures is removed  


