### PR TITLE
strict requirenments, disable verify_certs of opensearch, minor updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-requests >= 2.22.0
+requests == 2.22.0
 elasticsearch == 7.5.1
-pandas >= 0.25.0
-numpy >= 1.17.0
-boto3 >= 1.17.3
-pycognito >= 0.1.5
-requests-aws4auth >= 1.0.1
-python-dateutil >= 2.8.0
+pandas == 0.25.0
+numpy == 1.17.0
+boto3 == 1.17.3
+pycognito == 0.1.5
+requests-aws4auth == 1.0.1
+python-dateutil == 2.8.0

--- a/spot/config/config.ini.template
+++ b/spot/config/config.ini.template
@@ -60,7 +60,7 @@ retry_sleep_seconds = 900
 retry_attempts = 48
 
 [SPOT_ELASTICSEARCH]
-elasticsearch_url = https://localhost:9200
+elasticsearch_url = http://localhost:9200
 
 
 # The following authentication types for Elasticsearch are currently supported:

--- a/spot/crawler/elastic.py
+++ b/spot/crawler/elastic.py
@@ -43,6 +43,7 @@ class Elastic:
                                                timeout=REQUEST_TIMEOUT,
                                                retry_on_timeout=True,
                                                http_auth=http_auth,
+                                               verify_certs=False,
                                                connection_class=elasticsearch.RequestsHttpConnection)
         # Spark indexes
         self._raw_index = self._conf.elastic_raw_index
@@ -288,7 +289,7 @@ class Elastic:
             item['_id'] = app.get('id')
             item['_index'] = self._yarn_apps_index
             item['_op_type'] = 'index'
-            item['_type'] = '_doc'
+            #item['_type'] = '_doc'
             item['_source'] = app
             yield item
 
@@ -300,7 +301,7 @@ class Elastic:
             item = dict()
             item['_index'] = self._yarn_scheduler_index
             item['_op_type'] = 'create'
-            item['_type'] = '_doc'
+            #item['_type'] = '_doc'
             item['_source'] = doc
             yield item
 

--- a/spot/crawler/flattener.py
+++ b/spot/crawler/flattener.py
@@ -52,7 +52,7 @@ def rsd(series):
 # see https://pandas.pydata.org/pandas-docs/stable/reference/series.html
 default_type_aggregations = {
     np.number: [DF.min, DF.max, DF.sum, DF.mean, DF.nunique, count_zeroes, count_not_null],  # other possible:  DF.std, rsd
-    np.object: [count_not_null, pd.Series.nunique, concat_unique_values],  # corresponds to string type
+    #np.object: [count_not_null, pd.Series.nunique, concat_unique_values],  # corresponds to string type
     np.datetime64: [min, max],  # without timezone. Does not overlap with timezone aware columns
     'datetime64[ns, UTC]': [min, max],  # with ANY timezone (not limited to UTC). Preserves original column timezone.
                                         # WARNING: Column must have a single timezone.


### PR DESCRIPTION
- Strict definitions in requirements file
- disable verify_certs for opensearch
- remove doc type in opensearch calls (due to campability)
- remove aggregations for string attributes